### PR TITLE
Fixing dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ ESLINT_RAILS=~/src/eslint-rails-ee
 ## Cloning the repository
 
 ```sh
-git clone https://github.com/appfolio/eslint-rails-ee $ESLINT_RAILS
+git clone https://github.com/DLvalentine/eslint-rails-ee $ESLINT_RAILS
 ```
 
 ## Updating ESLint version

--- a/eslint-rails-ee.gemspec
+++ b/eslint-rails-ee.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'railties', '>= 3.2'
   spec.add_dependency 'execjs'
+  spec.add_dependency 'therubyracer'
   spec.add_dependency 'colorize'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'therubyracer'
 end

--- a/lib/eslint-rails-ee/engine.rb
+++ b/lib/eslint-rails-ee/engine.rb
@@ -1,3 +1,5 @@
+require 'rails/engine'
+
 module ESLintRails
   class Engine < Rails::Engine
   end

--- a/lib/eslint-rails-ee/runner.rb
+++ b/lib/eslint-rails-ee/runner.rb
@@ -1,3 +1,4 @@
+require 'action_view'
 require 'colorize'
 
 module ESLintRails


### PR DESCRIPTION
When using the gem in an optional bundler group like
`group :linters, optional: true do
gem 'eslint-rails-ee'
end`
and including this group in the boot.rb of your Rails project via
`Bundler.require(:linters)`
then eslint-rails-ee is missing some require statements.

I also added therubyracer as runtime dependency and fixed a broken reference in the readme.